### PR TITLE
Add custom formatter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with `webpack --watch` as it will run your tests every time a file changes.
 
 You can use the default formatter or pass the name of the TAP formatter of
 your choice to the plugin. It checks your PATH and pipes your TAP through
-whatever application it finds.
+whatever executable it finds.
 
 Note: You should use the `target: 'node'` option in your webpack configuration
 as the generated output will be run with Node.js.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is a plugin for [webpack][webpack-url] that runs the generated output
 bundle with Node.js and parses the output as [TAP][tap-url]. This works well
 with `webpack --watch` as it will run your tests every time a file changes.
 
+You can use the default formatter or pass the name of the TAP formatter of
+your choice to the plugin. It checks your PATH and pipes your TAP through
+whatever application it finds.
+
 Note: You should use the `target: 'node'` option in your webpack configuration
 as the generated output will be run with Node.js.
 

--- a/index.js
+++ b/index.js
@@ -27,12 +27,13 @@ TapWebpackPlugin.prototype.apply = function (compiler) {
     var useFormatter = false
     if (formatter && typeof formatter === 'string') {
       try {
-        useFormatter = true
-        var formatterProc = spawn(which.sync(formatter), {stdio: ['pipe', 1, 2]})
-        proc.stdout.pipe(formatterProc.stdin)
+        which.sync(formatter)
       } catch (e) {
         throw new Error('Formatter \'' + formatter + '\' not found')
       }
+      var formatterProc = spawn(which.sync(formatter), {stdio: ['pipe', 1, 2]})
+      useFormatter = true
+      proc.stdout.pipe(formatterProc.stdin)
     }
 
     proc.stdout.pipe(parser)

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function TapWebpackPlugin (formatter) {
     try {
       which.sync(formatter)
     } catch (e) {
-      throw new Error(`Formatter '${formatter}' not found`)
+      throw new Error('Formatter ' + formatter + ' not found')
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var tapOut = require('tap-out')
 var spawn = require('child_process').spawn
-var exec = require('child_process').exec
 var map = require('lodash/collection/map')
 var filter = require('lodash/collection/filter')
 var forEach = require('lodash/collection/forEach')
@@ -10,10 +9,9 @@ function TapWebpackPlugin (formatter) {
   this.formatter = formatter
 }
 
-TapWebpackPlugin.prototype.apply = function(compiler) {
+TapWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('after-emit', emitted)
   var formatter = this.formatter
-
   function emitted (compilation, callback) {
     var entry = filter(compilation.chunks, 'entry')
     var files = map(entry, function (c) { return c.files[0] })
@@ -27,10 +25,14 @@ TapWebpackPlugin.prototype.apply = function(compiler) {
     var proc = spawn(process.execPath, { stdio: ['pipe', 'pipe', 'inherit'] })
 
     var useFormatter = false
-    if (typeof formatter === 'string') {
-      useFormatter = true
-      var formatterProc = spawn(which.sync(formatter), {stdio: ['pipe', 1, 2]})
-      proc.stdout.pipe(formatterProc.stdin)
+    if (formatter && typeof formatter === 'string') {
+      try {
+        useFormatter = true
+        var formatterProc = spawn(which.sync(formatter), {stdio: ['pipe', 1, 2]})
+        proc.stdout.pipe(formatterProc.stdin)
+      } catch (e) {
+        throw new Error('Formatter \'' + formatter + '\' not found')
+      }
     }
 
     proc.stdout.pipe(parser)

--- a/index.js
+++ b/index.js
@@ -1,24 +1,18 @@
 var tapOut = require('tap-out')
 var spawn = require('child_process').spawn
+var exec = require('child_process').exec
 var map = require('lodash/collection/map')
 var filter = require('lodash/collection/filter')
 var forEach = require('lodash/collection/forEach')
 var which = require('which')
 
 function TapWebpackPlugin (formatter) {
-  if (formatter) {
-    try {
-      which.sync(formatter)
-    } catch (e) {
-      throw new Error('Formatter ' + formatter + ' not found')
-    }
-  }
-
-  return { apply: apply.bind(this, formatter) }
+  this.formatter = formatter
 }
 
-function apply (formatter, compiler) {
+TapWebpackPlugin.prototype.apply = function(compiler) {
   compiler.plugin('after-emit', emitted)
+  var formatter = this.formatter
 
   function emitted (compilation, callback) {
     var entry = filter(compilation.chunks, 'entry')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^3.10.1",
-    "tap-out": "^1.3.2"
+    "tap-out": "^1.4.1",
+    "which": "^1.2.4"
   },
   "devDependencies": {
     "standard": "^5.1.1",


### PR DESCRIPTION
I added the option to use custom TAP formatters. `new TapWebpackPlugin()` takes one argument; the name of the formatter. If it is found, it replaces the usual format. Otherwise an error is thrown. If no argument is passed, the plugin works as usual.
